### PR TITLE
fix: updates based on comments. url update, array -> slice in descriptio...

### DIFF
--- a/content/advent-2014/safe-json-file-db-in-go.md
+++ b/content/advent-2014/safe-json-file-db-in-go.md
@@ -118,7 +118,7 @@ Here's one of our jobs for interacting with the database. This job simply implem
 	}
 
 ### Todo Client
-This is the piece which the rest of your application will interact with. It encapsulates the mess associated with pushing jobs and waiting for a response and signal to come through on the error channel. It also maps the raw database model into a more reasonable result (an array in this case.)
+This is the piece which the rest of your application will interact with. It encapsulates the mess associated with pushing jobs and waiting for a response and signal to come through on the error channel. It also maps the raw database model into a more reasonable result (a slice in this case.)
 
 	// client for submitting jobs and providing a repository-like interface
 	type TodoClient struct {
@@ -140,7 +140,7 @@ This is the piece which the rest of your application will interact with. It enca
 		// Collect the found Todos
 		todos <-job.todos
 
-		// Convert Map to Array
+		// Convert Map to Slice
 		for _, value := range todos {
 			arr = append(arr, value)
 		}
@@ -184,7 +184,7 @@ And last but not least, we leverage the `TodoClient` to get some data... safely!
 		Client *TodoClient
 	}
 
-	// Get all todos as an array
+	// Get all todos as a slice
 	func (h *TodoHandlers) GetTodos(c *gin.Context) {
 		todos, err := h.Client.GetTodos()
 		if err != nil {

--- a/content/advent-2014/testing-microservices-in-go.md
+++ b/content/advent-2014/testing-microservices-in-go.md
@@ -66,7 +66,7 @@ Regardless, the reason we're even talking about clients is to support testing ou
 For `weather-go`, I start up an http server on a random port and use the client I've written to perform tests:
 
 ### Suite Setup
-I'm using [gocheck](gopkg.in/check.v1) which allows for things like `setup` and `teardown` functions in addition to higher level `Assert` calls. Following, I use these fixtures to boot a server to test against and to add/drop the location table.
+I'm using [gocheck](http://gopkg.in/check.v1) which allows for things like `setup` and `teardown` functions in addition to higher level `Assert` calls. Following, I use these fixtures to boot a server to test against and to add/drop the location table.
 
 	type TestSuite struct {
 		s *LocationService


### PR DESCRIPTION
a couple of updates in response to comments:
- fixed "gocheck" url to include protocol so it doesn't behave like a relative link
- updated descriptions to say "slice" instead of "array" where appropriate