### PR TITLE
Add pagination to front page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
   <div id="article-body">
-      {{ range .Data.Pages }}
+      {{ range .Paginator.Pages }}
 	      <article>
 		      <p class="lead">
             <a href="{{ .Permalink }}" class="article-title">{{ .Title }}</a>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,12 +1,3 @@
 <div class="row row-centered">
-
-  <ul class="pagination pagination-sm">
-    <li><a href="#">&laquo;</a></li>
-    <li><a href="#">1</a></li>
-    <li><a href="#">2</a></li>
-    <li><a href="#">3</a></li>
-    <li><a href="#">4</a></li>
-    <li><a href="#">5</a></li>
-    <li><a href="#">&raquo;</a></li>
-  </ul>  
+-  {{ template "_internal/pagination.html" . }}
 </div>


### PR DESCRIPTION
As introduced in Hugo 0.13.

Note: This uses the default config values:

paginate = 10
paginatepath = "page"

Could be adjusted to more or less items per page and a different url pattern (this gives /page/1 etc.).