### PR TITLE
Create "GopherCon 2015" series

### DIFF
--- a/content/gophercon2015-speakers-round-1.md
+++ b/content/gophercon2015-speakers-round-1.md
@@ -3,7 +3,7 @@ author = ["Erik St. Martin"]
 date = "2015-04-10T12:37:00-04:00"
 linktitle = "GopherCon 2015 - Speakers Round 1"
 title = "GopherCon 2015 - Speakers Round 1"
-
+series = ["GopherCon 2015"]
 +++
 ## Call for Papers
 The <a href="http://gophercon.com">GopherCon 2015</a> Call for Papers was an incredible success. We received over 164 submissions from people all over the world. Our panel of 12 Go community members worked tirelessly to review and rate each proposal. It was a challenge to limit the talks to just 22, we only wish we had more speaking slots to fill.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -43,7 +43,8 @@
         function titleize(slug) {
             var words = slug.split("-");
             return words.map(function(word) {
-                return word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
+                var series = word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
+		return series.replace("Gophercon", "GopherCon");
             }).join(' ');
         }
         var str = "{{$name}}";
@@ -99,7 +100,8 @@
         function titleize(slug) {
             var words = slug.split("-");
             return words.map(function(word) {
-                return word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
+                var series = word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
+		return series.replace("Gophercon", "GopherCon");
             }).join(' ');
         }
         var str = "{{$name}}";


### PR DESCRIPTION
I wanted to create a new series for the gophercon posts this year.

Future posts should be in a subdirectory gophercon-2015/, but the first
announcement will have to stay where it is to avoid breaking inbound links.

I've included a hack which correctly capitalises the slug in the left nav
but cannot figure out how to do the same for the summary page that the
slug send you to.

Change-Id: I42c88fb681c82af0cbb9337b21de66798ae822e1