### PR TITLE
Fix GoPy publication date

### DIFF
--- a/content/advent-2015/gopy.md
+++ b/content/advent-2015/gopy.md
@@ -1,6 +1,6 @@
 +++
 author = ["Sebastien Binet"]
-date = "2015-12-16T00:00:00+01:00"
+date = "2015-12-17T00:00:00+01:00"
 linktitle = "Gopy"
 series = ["Advent 2015"]
 title = "gopy: extending CPython with Go"


### PR DESCRIPTION
There are 2 articles published on the 16th

![series](https://cloud.githubusercontent.com/assets/65201/11917146/2a49d1fe-a6fb-11e5-8674-4cc381be04da.png)

Shouldn't GoPy article be published on the 17th?
