### PR TITLE
advent-2016: TLS termination nits

### DIFF
--- a/content/advent-2016/tls-termination-bench.md
+++ b/content/advent-2016/tls-termination-bench.md
@@ -9,18 +9,18 @@ series = ["Advent 2016"]
 
 +++
 
-With the advent of letsencrypt, it's now easier than ever before to ensure all 
+With the advent of Let's Encrypt, it's now easier than ever before to ensure all 
 of your web applications and services are behind HTTPS. However, many times it's
 hard to realize the performance impact and overhead of using HTTPS on your 
 applications. Should you terminate in Nginx? Go? Stunnel? ELBs?
 
 Luckily, it's fairly easy to find out with a simple benchmark. We'll put a 
-Hello World server, written in Go, behind Nginx, set up as a SSL-terminating
+Hello World server, written in Go, behind Nginx, set up as a TLS-terminating
 reverse proxy, and compare that to the native `http.ListenAndServeTLS`. 
 
 I set up a very small test case for this, (find it [here](https://github.com/fortytw2/dirty-ssl-bench))
 to compare the two. Looking at Nginx 1.10.2 w/ OpenSSL 1.0.2j vs Go 1.7.3, the 
-quick (and not very scientific) benchmark using [vegeta](https://github.com/tsenart/vegeta) shows us the following 
+quick (and not very scientific) benchmark using [Vegeta](https://github.com/tsenart/vegeta) shows us the following 
 
 
 Nginx (reverse proxy to Go)
@@ -55,13 +55,13 @@ Error Set:
 
 Admittedly, this is a fairly unfair benchmark, as the Nginx benchmark has the overhead of 
 reverse proxying in it. However, this is fair, as we care most about "real world" numbers, 
-not arbitrary SSL termination benchmarks, as you can't exactly terminate SSL in Nginx and then
+not arbitrary TLS termination benchmarks, as you can't exactly terminate TLS in Nginx and then
 use it for anything if there's no proxying going on (in most cases).
 
 It's very nice to see Go have lower non-tail latencies, as the last time I ran a benchmark like this (Go 1.2ish era)
 Go was rather far behind Nginx, even with the reverse proxy overhead. In conclusion,
-it's probably no longer worth it to just run Nginx in front of your Go app to terminate SSL and proxy to Go, as 
-Go is perfectly capable of doing so performantly (and has a _awesome_ variety of easy to use letsencrypt clients, which
-nginx still lacks native support for).
+it's probably no longer worth it to just run Nginx in front of your Go app to terminate TLS and proxy to Go, as 
+Go is perfectly capable of doing so performantly (and has an _awesome_ variety of easy to use Let's Encrypt clients, which
+Nginx still lacks native support for).
 
 If you have ideas to improve this benchmark (or if I did something horribly wrong...) find me anywhere as fortytw2 :)


### PR DESCRIPTION
Two minor nits:

- letsencrypt should be Let's Encrypt
- SSL should be TLS (as per title)
- nginx should be Nginx (only one occurrence)
- vegeta should be Vegeta
- a awesome should be an awesome

/cc @fortytw2 @dgryski 