### PR TITLE
Advent 2016: Update go dep mgmt saga timeline with tool url

### DIFF
--- a/content/advent-2016/saga-go-dependency-management.md
+++ b/content/advent-2016/saga-go-dependency-management.md
@@ -104,3 +104,4 @@ _Note: We make no pretense that this list is exhaustive!_
 
 Comments can be made right here, but may be more productive if channeled to Peter Bourgon, the #vendor channel on the Gopher slack, or the [go-pm](https://groups.google.com/forum/#!forum/go-package-management) mailing list.
 
+Update: In January 2017 [dep](https://github.com/golang/dep) was made public.


### PR DESCRIPTION
Now the tool has been released, we should link to it so future readers can unambiguously find it.

This is a purely optional update.

cc @sdboyer 