### PR TITLE
Support latest Hugo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ that it looks correct before submitting a pull request.
 To view the site on your local machine, you need to do the following:
 
 1. Clone the repo
-2. Install [Hugo](http://hugo.spf13.com)
+2. Install [Hugo](https://gohugo.io/)
 
 Once Hugo is installed, run it from the cloned repo using:
 

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseurl = "https://blog.gopheracademy.com"
 languageCode = "en-us"
 title = "Gopher Academy Blog"
 disqusShortname = "gopheracademy"
+theme = "gaweb"
 [taxonomies]
    author = "authors"
    series = "series"


### PR DESCRIPTION
Sometime between 0.15 (the version running in production) and 0.31
(the current version), Hugo requires you to specify which theme you
are using, which in our case is "gaweb".

Not sure how best to test this, but without this patch hugo renders an
empty page, and with it, hugo renders the blog server.