### PR TITLE
Improve instructions for hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ To view the site on your local machine, you need to do the following:
 
 Once Hugo is installed, run it from the cloned repo using:
 
-	hugo server --watch
+	hugo server --watch --buildDrafts --buildFuture
 
 To view the site, visit the link provided by Hugo, usually `http://localhost:1313`.


### PR DESCRIPTION
The new command line build drafts and future posts so contributors can preview series posts that haven't reached their post date yet.

I struggled with this and at least one other contributor reported being unable to build the site locally to preview an article, so I think it's good to have the instructions here.